### PR TITLE
Alternate error highlighting

### DIFF
--- a/src/components/beat.js
+++ b/src/components/beat.js
@@ -537,7 +537,8 @@ AFRAME.registerComponent('beat', {
 					if (
 						bombs[i].spawnTime < data.time + 0.01 &&
 						bombs[i].spawnTime > data.time - 0.01 &&
-						(!bombs[i].id || bombs[i].id == data.noteId || bombs[i].id == data.noteIdWithScoring)
+						// We only care about matching lineIndex*1000 and noteLineLayer*100 from the ID
+						(!bombs[i].id || Math.floor((bombs[i].id % 10000) / 100) == Math.floor((data.noteId % 10000) / 100))
 					) {
 						this.replayNote = bombs[i];
 						break;
@@ -875,11 +876,11 @@ AFRAME.registerComponent('beat', {
 			this.returnToPool(true);
 		}
 
-		if (!settings.settings.noEffects) {
-			this.explodeEventDetail.position.copy(this.el.object3D.position);
-			this.explodeEventDetail.rotation.copy(this.randVec);
-			mineParticles.emit('explode', this.explodeEventDetail, false);
-		}
+		// if (!settings.settings.noEffects) {
+		// 	this.explodeEventDetail.position.copy(this.el.object3D.position);
+		// 	this.explodeEventDetail.rotation.copy(this.randVec);
+		// 	mineParticles.emit('explode', this.explodeEventDetail, false);
+		// }
 	},
 
 	destroyBeat: (function () {

--- a/src/components/beat.js
+++ b/src/components/beat.js
@@ -566,11 +566,7 @@ AFRAME.registerComponent('beat', {
 		}
 
 		if (settings.settings.highlightErrors && this.replayNote && this.replayNote.score < 0) {
-			if (data.type == 'mine') {
-				this.blockEl.getObject3D('mesh').material = this.el.sceneEl.systems.materials['mineMaterialyellow'];
-			} else {
-				this.blockEl.setAttribute('material', 'color: yellow');
-			}
+			this.blockEl.setAttribute('material', 'emissive: yellow; emissiveIntensity: 0.6');
 		}
 
 		const replay = replayLoader.replay;

--- a/src/components/beat.js
+++ b/src/components/beat.js
@@ -537,8 +537,7 @@ AFRAME.registerComponent('beat', {
 					if (
 						bombs[i].spawnTime < data.time + 0.01 &&
 						bombs[i].spawnTime > data.time - 0.01 &&
-						// We only care about matching lineIndex*1000 and noteLineLayer*100 from the ID
-						(!bombs[i].id || Math.floor((bombs[i].id % 10000) / 100) == Math.floor((data.noteId % 10000) / 100))
+						(!bombs[i].id || bombs[i].id == data.noteId || bombs[i].id == data.noteIdWithScoring)
 					) {
 						this.replayNote = bombs[i];
 						break;
@@ -566,7 +565,7 @@ AFRAME.registerComponent('beat', {
 		}
 
 		if (settings.settings.highlightErrors && this.replayNote && this.replayNote.score < 0) {
-			this.blockEl.setAttribute('material', 'emissive: yellow; emissiveIntensity: 0.6');
+			this.blockEl.setAttribute('material', 'emissive: #4b4d00; emissiveIntensity: 0.9');
 		}
 
 		const replay = replayLoader.replay;
@@ -738,8 +737,6 @@ AFRAME.registerComponent('beat', {
 		var fragments = this.el.sceneEl.systems['mine-fragments-loader'].fragments.children;
 		var material = this.el.sceneEl.systems.materials['mineMaterial' + this.data.color];
 
-		this.randVec = new THREE.Vector3(Math.random() * Math.PI, Math.random() * Math.PI, Math.random() * Math.PI);
-
 		this.mineFragments = [];
 		this.mineBroken = document.createElement('a-entity');
 		this.el.appendChild(this.mineBroken);
@@ -872,11 +869,11 @@ AFRAME.registerComponent('beat', {
 			this.returnToPool(true);
 		}
 
-		// if (!settings.settings.noEffects) {
-		// 	this.explodeEventDetail.position.copy(this.el.object3D.position);
-		// 	this.explodeEventDetail.rotation.copy(this.randVec);
-		// 	mineParticles.emit('explode', this.explodeEventDetail, false);
-		// }
+		if (!settings.settings.noEffects) {
+			this.explodeEventDetail.position.copy(this.el.object3D.position);
+			this.explodeEventDetail.rotation.copy(new THREE.Vector3(Math.random() * Math.PI, Math.random() * Math.PI, Math.random() * Math.PI));
+			mineParticles.emit('explode', this.explodeEventDetail, false);
+		}
 	},
 
 	destroyBeat: (function () {

--- a/src/components/materials.js
+++ b/src/components/materials.js
@@ -113,14 +113,6 @@ AFRAME.registerSystem('materials', {
 			emissive: new THREE.Color(COLORS.MINE_BLUE_EMISSION),
 			envMap: new THREE.TextureLoader().load('assets/img/mineenviro-blue.jpg'),
 		});
-
-		this.mineMaterialyellow = new THREE.MeshStandardMaterial({
-			roughness: 0.38,
-			metalness: 0.48,
-			color: new THREE.Color('yellow'),
-			emissive: new THREE.Color('yellow'),
-			envMap: new THREE.TextureLoader().load('assets/img/mineenviro-blue.jpg'),
-		});
 	},
 });
 

--- a/src/index.html
+++ b/src/index.html
@@ -155,6 +155,11 @@
       </a-entity>
 
       <a-entity
+        render-order="wall"
+        id="mineParticles"
+        particleplayer="src: #mineParticlesJSON; pscale: 0.5; interpolate: true; scale: 1.4; loop: false; on: explode; img: #sparkImg; count: 20%; animateScale: true; initialScale: 3 1 1; finalScale: 0.2 0.2 1"></a-entity>
+
+      <a-entity
         id="controllerRig"
         proxy-event="event: recentered; to: #headRig; captureBubbles: true; as: recenter">
         {% macro saber (hand, otherHand, bladeColor, beamColor) %}

--- a/src/utils/mapPostprocessor.js
+++ b/src/utils/mapPostprocessor.js
@@ -302,7 +302,7 @@ function addScoringTypeAndChains(map) {
 		if (note._type == 1 || note._type == 0) {
 			note._scoringType = ScoringType.Normal;
 		} else {
-			note._scoringType = ScoringType.Ignore;
+			note._scoringType = ScoringType.NoScore;
 		}
 	});
 


### PR DESCRIPTION
This changes the error highlighting to use the material emissive property instead of base color, which allows you to better differentiate the highlighted note colors.

![screenshot](https://user-images.githubusercontent.com/1782216/230829739-bc6d74cd-09fd-4726-8801-5bd56aa000da.png)

Feel free to reject this if you don't like it.

Note this branch also contains the changes from #24