### PR TITLE
Fixes for various hitsound issues when "real hitsound" is disabled

### DIFF
--- a/src/components/beat-generator.js
+++ b/src/components/beat-generator.js
@@ -305,6 +305,7 @@ AFRAME.registerComponent('beat-generator', {
 		this.clearBeats(true);
 		this.beatsTime = time;
 		this.isSeeking = true;
+		this.el.sceneEl.components['beat-hit-sound'].beatSeekReset = true;
 
 		if (this.getRotation(time) != this.spawnRotation.rotation) {
 			this.el.sceneEl.emit('spawnRotationChanged', {spawnRotation: this.getRotation(time), oldSpawnRotation: this.spawnRotation}, false);


### PR DESCRIPTION
 - Fix hitsounds not playing when rewinding to an earlier part of the song
 - Add a fallback to still play a hitsound if a note is skipped during playback
 - Hitsounds now work properly for different playback speeds