### PR TITLE
Real hitsounds: fix hitsound delay and update to not play hitsound on miss

### DIFF
--- a/src/components/beat-hit-sound.js
+++ b/src/components/beat-hit-sound.js
@@ -67,7 +67,11 @@ AFRAME.registerComponent('beat-hit-sound', {
 		var source = this.sources.pop();
 		if (source == null) return;
 
-		source.start(0);
+		if (!this.settings.settings.realHitsounds) {
+			source.start(0);
+		} else {
+			source.start(0, 0.15);
+		}
 		setTimeout(() => {
 			this.addNewSource();
 		}, 1000);

--- a/src/components/beat.js
+++ b/src/components/beat.js
@@ -848,7 +848,7 @@ AFRAME.registerComponent('beat', {
 		} else {
 			setTimeout(scoreChanged, timeToScore * 1000);
 		}
-		if (this.data.type !== 'sliderchain' && settings.settings.realHitsounds && Math.abs(timeToScore) < 0.1) {
+		if (this.data.type !== 'sliderchain' && settings.settings.realHitsounds && Math.abs(timeToScore) < 0.1 && (this.replayNote.eventType == 0 || this.replayNote.eventType == 1)) {
 			hitSound.playSound();
 		}
 	},


### PR DESCRIPTION
 - Real hitsound audio playback now begins at 0.15s to skip dead audio in default hitsound file. Note that this constant 0.15s offset also applies to non-default hitsounds, which may have a different offset. A similar offset is already being applied when real hitsounds are disabled, so it's probably fine.
 - Real hitsounds now only play for good cuts and bad cuts, not misses. Previously misses could play a hitsound on despawning.